### PR TITLE
Numpyerror

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ stack.plot()
 
 ### Integration with Pandas
 
-Data from a Raster object can converted into a Pandas dataframe, with each pixel representing by a row, and columns
+Data from a Raster object can be converted into a Pandas dataframe, with each pixel representing by a row, and columns
 reflecting the x, y coordinates and the values of each RasterLayer in the Raster object:
 
 ```

--- a/pyspatialml/raster.py
+++ b/pyspatialml/raster.py
@@ -2560,7 +2560,7 @@ class Raster(_LocIndexer, RasterStats, RasterPlot):
 
         dtype = np.find_common_type([np.float32], self.dtypes)
         X = np.ma.zeros((self.count, 0), dtype=dtype)
-        pixel_indices = np.zeros(0, dtype=np.int)
+        pixel_indices = np.zeros(0, dtype=np.int_)
 
         for w, data, pbar in zip(windows, data_gen, t):
             res, chunk_pixels = extract_by_chunk(data, w, rowcol_idx, pixel_index)


### PR DESCRIPTION
As [venka-foss4g](https://github.com/venka-foss4g) suggested, I have modified line 2563 of `raster.py` to:

`pixel_indices = np.zeros(0, dtype=np.int_)`

As numpy.int has been removed in NumPy >= 1.24

https://stackoverflow.com/questions/74946845/attributeerror-module-numpy-has-no-attribute-int and also edited the grammatical error in the README file.